### PR TITLE
Fix scheduled backups being run at wrong times

### DIFF
--- a/src/dk/jens/backup/schedules/BootReceiver.java
+++ b/src/dk/jens/backup/schedules/BootReceiver.java
@@ -29,24 +29,11 @@ public class BootReceiver extends BroadcastReceiver
                 long repeat = (long)(prefs.getInt(
                     Constants.PREFS_SCHEDULES_REPEATTIME + i, 0) * AlarmManager.INTERVAL_DAY);
                 long timePassed = System.currentTimeMillis() - timePlaced;
-                long hourOfDay = handleAlarms.timeUntilNextEvent(0,
-                    prefs.getInt(Constants.PREFS_SCHEDULES_HOUROFDAY + i, 0));
                 long timeLeft = prefs.getLong(
                     Constants.PREFS_SCHEDULES_TIMEUNTILNEXTEVENT + i, 0) - timePassed;
                 if(timeLeft < (5 * 60000))
                 {
                     handleAlarms.setAlarm(i, AlarmManager.INTERVAL_FIFTEEN_MINUTES, repeat);
-                }
-                else if(timeLeft < (24 * AlarmManager.INTERVAL_HOUR))
-                {
-                    if(hourOfDay > 0)
-                    {
-                        handleAlarms.setAlarm(i, hourOfDay, repeat);
-                    }
-                    else
-                    {
-                        handleAlarms.setAlarm(i, AlarmManager.INTERVAL_FIFTEEN_MINUTES, repeat);
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #132 and #159 

#132 and #159, which are both the same issue, consist of two sub-issues, each of which is fixed by a separate commit in this PR for readability.

## Commit 1: Remove unnecessary and buggy else-if in BootReceiver#onReceive()

**Description of the bug (reffering to the code before this commit):**

Let's say a backup is scheduled for 2am and repeatTime is 1 day. Let's say the backup runs properly at 2am and the device reboots at 8am.
Then the BootReceiver#onReceive() method will be run and timeLeft will be greater than 15 minutes and smaller than 24 hours, so the code in the else-if will be executed.
As hourOfDay is negative (value is -6 hours), another backup will be scheduled to be run in 15 minutes, which is not needed, and (which will be fixed by commit 2) it will be run at the same wrong time again the next day since it has repeat set to AlarmManager.INTERVAL_DAY.

**Description of the fix:**

After removing the else-if, backups will be scheduled to be run 15 minutes after boot if they haven't been run yet (e.g. because the device was turned off), or it will simply schedule a backup at the proper time in the future if they have already been run.

## Commit 2:  Fix the time at which the backup will be run the next time in ScheduleService#onStartCommand()

**Description of the bug (reffering to the code before this commit):**

If a backup is scheduled in BootReceiver#onReceive() to be run after 15 minutes, it will repeat at the same time in the future instead of at the time which the user specified for the backup.

**Description of the fix:**

We fix the time at which the backup will be run the next time in ScheduleService#onStartCommand().